### PR TITLE
Add potential gain column and sortable stock table

### DIFF
--- a/rr-site/styles.css
+++ b/rr-site/styles.css
@@ -11,6 +11,7 @@ button:hover{border-color:#3a66b1}
 .small{color:var(--muted);font-size:14px}
 table{width:100%;border-collapse:collapse}
 td,th{border-bottom:1px solid #203157;padding:8px;text-align:left}
+.sortable{cursor:pointer}
 .badge{display:inline-block;padding:4px 8px;border:1px solid #2a3a5d;border-radius:999px}
 .badge-green { border-color:#2d6a4f; color:#b7ebc6; }
 .badge-yellow { border-color:#8d6b2b; color:#ffe8a3; }


### PR DESCRIPTION
## Summary
- add Potential % Gain column based on current price vs high
- allow clicking headers to sort table columns
- style sortable headers with cursor feedback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6fe1aae5c832a83003718681c6ead