### PR TITLE
Add 3-point move formulas

### DIFF
--- a/rr-site/pages/index.js
+++ b/rr-site/pages/index.js
@@ -279,6 +279,12 @@ export default function Home() {
         <div>
           [10,1]: <code>score = 1 + 9 × log(high / price) / log(high / low)</code>
         </div>
+        <div>
+          3pt up: <code>price × (high / low)^(3 / (10 - topScore))</code>
+        </div>
+        <div>
+          3pt down: <code>price ÷ (high / low)^(3 / (10 - topScore))</code>
+        </div>
       </section>
 
       <section className="card small" style={{ lineHeight: 1.4 }}>


### PR DESCRIPTION
## Summary
- Add explicit formulas for calculating 3-point moves up and down

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b879beff6c832ab07d858018fe6509