### PR TITLE
Use Google Sheet for price data

### DIFF
--- a/rr-site/README.md
+++ b/rr-site/README.md
@@ -3,7 +3,7 @@
 
 This is a super-simple website that:
 - lets you type a stock ticker
-- fetches the **current price** using Alpha Vantage (free)
+- fetches the **current price** from a public Google Sheet
 - shows your **Risk/Reward high & low** lines from `data/rr.json`
 - has a **Subscribe** button you can point at your Stripe **Payment Link** for $1/month
 
@@ -25,7 +25,6 @@ No monthly fees to run: host on **Vercel (free)** + Stripe fees only when someon
 ### 2) Connect Vercel to that repo
 1. Go to https://vercel.com/new → click **GitHub** and authorize (choose your `rr-site` repo).
 2. On the **“Environment Variables”** step, add:
-   - **Name:** `ALPHA_VANTAGE_KEY` → **Value:** YOUR_KEY (you already created this)
    - **Name:** `NEXT_PUBLIC_STRIPE_LINK` → **Value:** your Stripe **Payment Link URL**
      - (In Stripe: Products → your $1 product → **Payment Links** → create a link → copy URL)
 3. Click **Deploy**. In ~1–2 minutes you’ll get a live URL like `https://rr-site-yourname.vercel.app`.

--- a/rr-site/pages/api/tickers.js
+++ b/rr-site/pages/api/tickers.js
@@ -25,6 +25,7 @@ export default async function handler(req, res) {
       low: header.findIndex((h) => /(green|low)/i.test(h)),
       high: header.findIndex((h) => /(red|high)/i.test(h)),
       pick: header.findIndex((h) => /pick/i.test(h)),
+      price: header.findIndex((h) => /(price|close|last)/i.test(h)),
       chart: header.findIndex((h) => /chart/i.test(h)), // optional
     };
 
@@ -34,6 +35,7 @@ export default async function handler(req, res) {
         low: Number(r[idx.low]),
         high: Number(r[idx.high]),
         pickType: (r[idx.pick] || "").toUpperCase(),
+        price: idx.price >= 0 ? Number(r[idx.price]) : null,
         chartUrl: idx.chart >= 0 ? (r[idx.chart] || "").trim() : "",
       }))
       .filter((x) => x.ticker && isFinite(x.low) && isFinite(x.high));


### PR DESCRIPTION
## Summary
- Pull ticker prices, highs, lows and picks from a shared Google Sheet
- Read price data from the sheet for `/api/price` instead of Alpha Vantage
- Remove Alpha Vantage usage from scheduled crossing checks and update docs
- Handle non-JSON responses from ticker list during cron runs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e2f9b08832a858f3f2044ead01a