### PR TITLE
Avoid stale stock prices from KV cache

### DIFF
--- a/rr-site/pages/api/price.js
+++ b/rr-site/pages/api/price.js
@@ -29,10 +29,12 @@ export default async function handler(req, res) {
       return res.status(200).json(cached.data);
     }
 
+    const today = new Date().toISOString().slice(0, 10);
+
     // 1) Try KV snapshot first (populated by /api/cron/check-crossings)
     const stateKey = `alert:${symbol}`;
     const snap = await kv.get(stateKey);
-    if (snap?.lastClose && snap?.lastDate) {
+    if (snap?.lastClose && snap?.lastDate === today) {
       // backward-compatible: still return { price }, but include extras too
       const result = {
         price: snap.lastClose,
@@ -71,7 +73,6 @@ export default async function handler(req, res) {
       return res.status(404).json({ error: "no price" });
     }
 
-    const today = new Date().toISOString().slice(0, 10);
     await kv.set(stateKey, {
       ...(snap || {}),
       lastClose: price,


### PR DESCRIPTION
## Summary
- Ensure `/api/price` only returns KV-snapshot values when the stored date matches today's date
- Always refresh stale KV entries from the Google Sheet so prices stay current

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'sharp')*

------
https://chatgpt.com/codex/tasks/task_e_68c5a73e4960832a9aa1c9bc090c3bbc